### PR TITLE
Added a readonly property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![npm version](https://badge.fury.io/js/ngx-property-grid.svg)](https://badge.fury.io/js/ngx-property-grid)
 [![Build Status](https://travis-ci.org/mokeyish/ngx-property-grid.svg?branch=master)](https://travis-ci.org/mokeyish/ngx-property-grid)
 
+Forked from ngx-property-grid 
+ - Adds readonly property 
+ - Adds ability to get meta data from a function not from property attributes.
+
 A small and simple property grid in angular to view/edit POJOs, excellent if you have a "settings" object you want to give the user to edit (that's why I have created it). [Play online](https://stackblitz.com/edit/angular-xd44ol).
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "ngx-property-grid",
-  "description": "A small and simple property grid in angular to view/edit POJOs, excellent if you have a \"settings\" object you want to give the user to edit.",
+  "name": "ngx-property-grid-sprotty",
+  "description": "Forked from ngx-property-grid - adds readonly property and ability to get meta data from a function not from property attributes.",
   "version": "9.0.5",
   "private": false,
   "authors": [
-    "mokeyish"
+    "mokeyish",
+    "sprotty"
   ],
   "keywords": [
     "angular",

--- a/projects/ngx-property-grid/package.json
+++ b/projects/ngx-property-grid/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "ngx-property-grid",
-  "description": "A small and simple property grid in angular to view/edit POJOs, excellent if you have a \"settings\" object you want to give the user to edit.",
+  "name": "ngx-property-grid-sprotty",
+  "description": "Forked from ngx-property-grid - adds readonly property and ability to get meta data from a function not from property attributes.",
   "version": "9.0.5",
   "private": false,
   "authors": [
-    "mokeyish"
+    "mokeyish",
+    "sprotty"
   ],
   "keywords": [
     "angular",

--- a/projects/ngx-property-grid/package.json
+++ b/projects/ngx-property-grid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-property-grid-sprotty",
   "description": "Forked from ngx-property-grid - adds readonly property and ability to get meta data from a function not from property attributes.",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "private": false,
   "authors": [
     "mokeyish",

--- a/projects/ngx-property-grid/src/lib/IPropertyGridMetaDataProvider.ts
+++ b/projects/ngx-property-grid/src/lib/IPropertyGridMetaDataProvider.ts
@@ -1,0 +1,6 @@
+import { PropertyItemMeta } from './property-item-meta';
+
+export interface IPropertyGridMetaDataProvider {
+    providePropertyGridMetaData(): PropertyItemMeta[];
+}
+

--- a/projects/ngx-property-grid/src/lib/dynamic-component-load.directive.ts
+++ b/projects/ngx-property-grid/src/lib/dynamic-component-load.directive.ts
@@ -15,20 +15,21 @@ import { IDynamicComponent } from './dynamic-component';
 })
 export class DynamicComponentLoadDirective implements OnInit, OnDestroy {
   private readonly _controlValueChangeFn: (value: any) => void;
-  private component: ComponentRef<IDynamicComponent<any>>;
+  private component!: ComponentRef<IDynamicComponent<any>>;
   private get componentType(): Type<PropertyValueAccess> {
     return this.meta.type as Type<PropertyValueAccess>;
   }
 
-  @Input('dynamicComponentLoad') private meta: PropertyItemMeta;
+  @Input('dynamicComponentLoad') 
+  private meta!: PropertyItemMeta;
   @Input()
   public options: any;
 
   constructor(private entry: ViewContainerRef, private componentFactoryResolver: ComponentFactoryResolver) {
     this._controlValueChangeFn = (value: any) => {
-      const oldValue = this.options[this.meta.key];
+      const oldValue = this.options[this.meta.key!];
       const newValue = this.meta.valueConvert ? this.meta.valueConvert(value) : value;
-      this.options[this.meta.key] = newValue;
+      this.options[this.meta.key!] = newValue;
       if (this.meta.valueChanged) {
         this.meta.valueChanged(newValue, oldValue);
       }
@@ -61,7 +62,7 @@ export class DynamicComponentLoadDirective implements OnInit, OnDestroy {
   }
 
   private initComponent(component: ComponentRef<PropertyValueAccess>) {
-    component.instance.value = this.options[this.meta.key]; 
+    component.instance.value = this.options[this.meta.key!]; 
     if (component.instance.registerOnChange) {
       component.instance.registerOnChange(this._controlValueChangeFn);
     }

--- a/projects/ngx-property-grid/src/lib/dynamic-component-load.directive.ts
+++ b/projects/ngx-property-grid/src/lib/dynamic-component-load.directive.ts
@@ -53,6 +53,7 @@ export class DynamicComponentLoadDirective implements OnInit, OnDestroy, OnChang
       // this.entry.clear();
       const componentFactory = this.componentFactoryResolver.resolveComponentFactory<PropertyValueAccess>(this.componentType);
       const component = this.entry.createComponent(componentFactory, 0);
+      component.instance["disabled"] = this.meta.readonly == true;
       this.initComponent(component);
       this.component = component;
     } catch (e) {

--- a/projects/ngx-property-grid/src/lib/property-grid.component.spec.ts
+++ b/projects/ngx-property-grid/src/lib/property-grid.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 // noinspection ES6PreferShortImport
 import {PropertyGridComponent} from './property-grid.component';
@@ -7,7 +7,7 @@ describe('PropertyGridComponent', () => {
     let component: PropertyGridComponent;
     let fixture: ComponentFixture<PropertyGridComponent>;
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
             declarations: [PropertyGridComponent]
         })

--- a/projects/ngx-property-grid/src/lib/property-grid.component.ts
+++ b/projects/ngx-property-grid/src/lib/property-grid.component.ts
@@ -24,7 +24,7 @@ import {PropertyValue} from './property-value';
             </tr>
 
             <ng-container *ngFor="let item of group.items">
-              <tr *ngIf="group.state">
+              <tr *ngIf="group.state" [attr.class]="item.readonly ? 'property-grid-readonly' : null">
                 <td [attr.colspan]="item.colSpan2 == true ? 2 : 1"
                     class="property-grid-label"
                     [style.cursor]="item.link ? 'pointer' : null"
@@ -90,15 +90,15 @@ import {PropertyValue} from './property-value';
     <ng-container *ngIf="!isInternal">
 
       <ng-template ngxTemplate="checkbox" let-p>
-        <input type="checkbox" [(ngModel)]="$any(p).value"/>
+        <input type="checkbox" [(ngModel)]="$any(p).value"  [disabled]="$any(p).readonly"/>
       </ng-template>
 
       <ng-template ngxTemplate="color" let-p>
-        <input type="color" [(ngModel)]="$any(p).value"/>
+        <input type="color" [(ngModel)]="$any(p).value" [disabled]="$any(p).readonly"/>
       </ng-template>
 
       <ng-template ngxTemplate="date" let-p>
-        <input type="date" [(ngModel)]="$any(p).value"/>
+        <input type="date" [(ngModel)]="$any(p).value" [disabled]="$any(p).readonly"/>
       </ng-template>
 
       <ng-template ngxTemplate="label" let-p>
@@ -106,11 +106,11 @@ import {PropertyValue} from './property-value';
       </ng-template>
 
       <ng-template ngxTemplate="text" let-p>
-        <input type="text" [(ngModel)]="$any(p).value"/>
+        <input type="text" [(ngModel)]="$any(p).value" [disabled]="$any(p).readonly"/>
       </ng-template>
 
       <ng-template ngxTemplate="options" let-p>
-        <select [(ngModel)]="$any(p).value">
+        <select [(ngModel)]="$any(p).value" [disabled]="$any(p).readonly">
           <option [value]="optionValue(option)" *ngFor="let option of $any(p).options">
             {{optionLabel(option)}}
           </option>
@@ -144,6 +144,9 @@ import {PropertyValue} from './property-value';
       .property-grid-label, .property-grid-control {
         border: dotted 1px #ccc;
         padding: 2px 5px;
+      }
+
+      .property-grid-readonly {
       }
 
       .internal-property-grid {

--- a/projects/ngx-property-grid/src/lib/property-grid.component.ts
+++ b/projects/ngx-property-grid/src/lib/property-grid.component.ts
@@ -232,13 +232,13 @@ export class PropertyGridComponent implements AfterContentInit, AfterViewInit {
   public readonly isInternal: boolean = false;
 
   @Input()
-  public templateMap: { [key: string]: TemplateRef<any> };
+  public templateMap!: { [key: string]: TemplateRef<any> };
 
   @Input()
   public state: 'hidden' | 'visible' = 'visible';
 
   @Input()
-  width: string | number;
+  width!: string | number;
 
 
   @Input()
@@ -263,19 +263,21 @@ export class PropertyGridComponent implements AfterContentInit, AfterViewInit {
     return this._options;
   }
 
-  onValueChanged():void{
+  onValueChanged(): void {
     this.initMeta();
-    this.cdr.detectChanges();
+    this.cdr.markForCheck();
   }
 
-  @ViewChildren(NgxTemplate) defaultTemplates: QueryList<NgxTemplate>;
-  @ContentChildren(NgxTemplate) templates: QueryList<NgxTemplate>;
+  @ViewChildren(NgxTemplate) defaultTemplates!: QueryList<NgxTemplate>;
+  @ContentChildren(NgxTemplate) templates!: QueryList<NgxTemplate>;
 
-  public groups: InternalGroup[];
-  public subItems: PropertyItemMeta[];
+  public groups!: InternalGroup[];
+  public subItems!: PropertyItemMeta[];
 
   constructor(el: ElementRef<HTMLElement>, private cdr: ChangeDetectorRef) {
-    this.isInternal = el.nativeElement.parentElement && el.nativeElement.parentElement.classList &&
+    this.isInternal =
+      el.nativeElement.parentElement != null &&
+      el.nativeElement.parentElement.classList &&
       el.nativeElement.parentElement.classList.contains('internal-property-grid');
   }
 
@@ -312,7 +314,7 @@ export class PropertyGridComponent implements AfterContentInit, AfterViewInit {
     }
   }
 
-  public getTemplate(type: string): TemplateRef<any> {
+  public getTemplate(type: string): TemplateRef<any> | undefined {
     if (typeof type === 'string' && this.templateMap) {
       return type ? this.templateMap[type] : this.templateMap.default;
     } else {
@@ -324,7 +326,7 @@ export class PropertyGridComponent implements AfterContentInit, AfterViewInit {
     if (meta.type instanceof Type) {
       return 'dynamicComponent';
     }
-    if (this.getTemplate(meta.type)) {
+    if (this.getTemplate(meta.type!)) {
       return 'template';
     }
     return 'templateNotFound';
@@ -377,7 +379,7 @@ export class PropertyGridComponent implements AfterContentInit, AfterViewInit {
       }
       group.items.push(v);
     }
-    groups.forEach(o => o.items.sort((a, b) => a.order - b.order));
+    groups.forEach(o => o.items.sort((a, b) => (a.order??0) - (b.order??0)));
 
     this.groups = groups.filter(o => o.items.length > 0);
     this.subItems = subItems;
@@ -411,6 +413,6 @@ export class InternalGroup {
     this.state = !this.state;
   }
 
-  constructor(public name: string) {
+  constructor(public name: string|undefined) {
   }
 }

--- a/projects/ngx-property-grid/src/lib/property-item-meta.ts
+++ b/projects/ngx-property-grid/src/lib/property-item-meta.ts
@@ -8,6 +8,7 @@ export interface PropertyItemMeta {
   description?: string; // A description of the property, will be used as tooltip on an hint element (a span with text "[?]")
   order?: number; // The display order.
   group?: string; //  The group this property belongs to
+  readonly?: boolean; // Whether this property should be readonly, default is false (can be omitted), when set it also adds the 'property-grid-readonly' style onto the 'tr' element.
   hidden?: boolean; // Whether this property should be hidden in the grid, default is false (can be omitted).
   initState?: 'hidden' | 'visible'; // - hidden/visible. If hidden then subItems should init by hidden state. default is hidden
   type?: 'color' | 'date' | 'checkbox' | 'text' | 'options' | string | Type<ControlValueAccessor | IDynamicComponent<any>>;

--- a/projects/ngx-property-grid/src/lib/property-item-meta.ts
+++ b/projects/ngx-property-grid/src/lib/property-item-meta.ts
@@ -60,7 +60,7 @@ export const meta = (itemMeta: PropertyItemMeta) =>
     } else if (target.__proto__.__meta__ === __meta__) {
       const subMeta = Object.create(Object.getPrototypeOf(__meta__));
       Object.getOwnPropertyNames(__meta__).forEach(name => {
-        Object.defineProperty(subMeta, name, Object.getOwnPropertyDescriptor(__meta__, name));
+        Object.defineProperty(subMeta, name, Object.getOwnPropertyDescriptor(__meta__, name)!);
       });
       __meta__ = subMeta;
       target.__meta__ = __meta__;

--- a/projects/ngx-property-grid/src/lib/property-value.ts
+++ b/projects/ngx-property-grid/src/lib/property-value.ts
@@ -1,3 +1,4 @@
+import { PropertyGridComponent } from './property-grid.component';
 import {PropertyItemMeta} from './property-item-meta';
 
 export class PropertyValue {
@@ -13,6 +14,7 @@ export class PropertyValue {
     if (this.meta.valueChanged) {
       this.meta.valueChanged(newValue, oldValue);
     }
+    this.propertyGrid.onValueChanged();
   }
 
   public get readonly(): boolean {
@@ -23,6 +25,6 @@ export class PropertyValue {
     return this.meta.options;
   }
 
-  constructor(private o: any, public meta: PropertyItemMeta) {
+  constructor(private propertyGrid: PropertyGridComponent, private o: any, public meta: PropertyItemMeta) {
   }
 }

--- a/projects/ngx-property-grid/src/lib/property-value.ts
+++ b/projects/ngx-property-grid/src/lib/property-value.ts
@@ -1,21 +1,28 @@
 import { PropertyGridComponent } from './property-grid.component';
-import {PropertyItemMeta} from './property-item-meta';
+import { PropertyItemMeta } from './property-item-meta';
 
 export class PropertyValue {
   public get value(): any {
-    return this.o[this.meta.key];
+    try {
+      return this.o[this.meta.key!];
+    }
+    catch (error) {
+      console.warn(`Failed to get property grid value '${String(this.meta.key)}'. Error : ${error}`);
+    }
   }
 
   public set value(val: any) {
-    const oldValue = this.o[this.meta.key];
+    const oldValue = this.o[this.meta.key!];
     const newValue = this.meta.valueConvert ? this.meta.valueConvert(val) : val;
 
-    this.o[this.meta.key] = newValue;
+    this.o[this.meta.key!] = newValue;
     if (this.meta.valueChanged) {
       this.meta.valueChanged(newValue, oldValue);
     }
     this.propertyGrid.onValueChanged();
   }
+
+
 
   public get readonly(): boolean {
     return this.meta.readonly == true;

--- a/projects/ngx-property-grid/src/lib/property-value.ts
+++ b/projects/ngx-property-grid/src/lib/property-value.ts
@@ -15,6 +15,10 @@ export class PropertyValue {
     }
   }
 
+  public get readonly(): boolean {
+    return this.meta.readonly == true;
+  }
+
   public get options(): any {
     return this.meta.options;
   }

--- a/projects/ngx-property-grid/src/public-api.ts
+++ b/projects/ngx-property-grid/src/public-api.ts
@@ -7,3 +7,4 @@ export * from './lib/property-grid.component';
 export * from './lib/property-item-meta';
 export * from './lib/property-value';
 export * from './lib/dynamic-component';
+export * from './lib/IPropertyGridMetaDataProvider';

--- a/src/app/showcase/app.component.html
+++ b/src/app/showcase/app.component.html
@@ -1,4 +1,12 @@
 <div>
+    <button (click)="onHandleReset()">Reset Data</button> 
+</div>
+<mat-radio-group  [(ngModel)]="metaDataType">
+    <mat-radio-button value="static">Static Meta Data</mat-radio-button>
+    <mat-radio-button value="dynamic">Dynamic Meta Data (hint : change the gender radio)</mat-radio-button>
+</mat-radio-group>
+
+<div>
     <h1 style="text-align: center">Property Grid Example</h1>
     <div style="display: flex; flex-direction: row">
 
@@ -12,7 +20,7 @@
             </ng-template>
 
             <ng-template ngxTemplate="date" let-p>
-                <input matInput [matDatepicker]="picker" placeholder="Choose a date" [(ngModel)]="p.value" [disabled]="p.readonly">
+                <input matInput [matDatepicker]="picker" placeholder="Choose a date" [value]="p.value" (dateChange)="p.value=$event.target.value"  [disabled]="p.readonly">
                 <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                 <mat-datepicker #picker></mat-datepicker>
             </ng-template>
@@ -30,5 +38,4 @@
           <ngx-json-view [data]="data" [levelOpen]="1"></ngx-json-view>
         </div>
     </div>
-
 </div>

--- a/src/app/showcase/app.component.html
+++ b/src/app/showcase/app.component.html
@@ -4,21 +4,21 @@
 
         <ngx-property-grid [width]="'400px'" [options]="student" [showHelp]="true" [groupCollapse]="true" [cardStyle]="student.editor.cardStyle">
             <ng-template ngxTemplate="text" let-p>
-                <input type="text" [value]="p.value" (change)="p.value = $event.target.value">
+                <input type="text" [value]="p.value" (change)="p.value = $event.target.value" [disabled]="p.readonly">
             </ng-template>
             <ng-template ngxTemplate="fontSize" let-pp>
-                <input matInput type="number" placeholder="Value" [(ngModel)]="pp.value">
+                <input matInput type="number" placeholder="Value" [(ngModel)]="pp.value" [disabled]="pp.readonly">
                 <!--<span>字体大小</span>-->
             </ng-template>
 
             <ng-template ngxTemplate="date" let-p>
-                <input matInput [matDatepicker]="picker" placeholder="Choose a date" [(ngModel)]="p.value">
+                <input matInput [matDatepicker]="picker" placeholder="Choose a date" [(ngModel)]="p.value" [disabled]="p.readonly">
                 <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                 <mat-datepicker #picker></mat-datepicker>
             </ng-template>
 
             <ng-template ngxTemplate="sex" let-p>
-                <mat-radio-group  [(ngModel)]="p.value">
+                <mat-radio-group  [(ngModel)]="p.value" [disabled]="p.readonly">
                     <mat-radio-button value="male">male</mat-radio-button>
                     <mat-radio-button value="female">female</mat-radio-button>
                 </mat-radio-group>

--- a/src/app/showcase/app.component.ts
+++ b/src/app/showcase/app.component.ts
@@ -1,23 +1,52 @@
-import {Component, EventEmitter} from '@angular/core';
-import {MatCheckbox} from '@angular/material/checkbox';
-import {MatSlideToggle} from '@angular/material/slide-toggle';
-import {IDynamicComponent, meta} from 'ngx-property-grid';
+import { Component, EventEmitter } from '@angular/core';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { IDynamicComponent, meta, PropertyItemMeta } from 'ngx-property-grid';
+import { IPropertyGridMetaDataProvider } from 'projects/ngx-property-grid/src/lib/IPropertyGridMetaDataProvider';
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html'
 })
 export class AppComponent {
-    public student: ExampleStudentOptions = new ExampleStudentOptions();
+    private _metaDataType: string = "static";
+    public student: IExampleStudentOptions = new ExampleStudentOptions();
 
     constructor() {
     }
+
+    public get metaDataType(): string { return this._metaDataType; }
+    public set metaDataType(value: string) {
+        this._metaDataType = value;
+        if (value == 'static')
+            this.student = new ExampleStudentOptions();
+        else
+            this.student = new DynamicExampleStudentOptions();
+    }
+
 
     public get data(): string {
         return JSON.parse(JSON.stringify(this.student));
     }
 
     text: string;
+
+    onHandleReset(): void {
+        this.student.age = 1;
+        this.student.birth = '2000-01-01';
+        this.student.description = 'default';
+        this.student.gender = 'male';
+        this.student.name = 'default';
+        this.student.telephone = '0000000000';
+        this.student.editor.cardStyle = false;
+        this.student.editor.font = 'Courier New';
+        this.student.editor.fontColor = '#000000';
+        this.student.editor.fontSize = 10;
+        this.student.editor.framework = 'None';
+        this.student.editor.jQuery = false;
+        this.student.editor.modernizr = false;
+    }
+
 }
 
 @Component({
@@ -31,23 +60,26 @@ export class SimpleTextEditorComponent implements IDynamicComponent<string> {
     disabledChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 }
 
+
 export class ExampleEditorOptions {
+    constructor() { }
+
     @meta({
         name: 'Font', description: 'The font editor to use', colSpan2: false,
         type: SimpleTextEditorComponent, group: 'Editor', hidden: false
     })
     font = 'Source Code Pro';
 
-    @meta({name: 'Font size', group: 'Editor', valueConvert: parseInt, type: 'fontSize'})
+    @meta({ name: 'Font size', group: 'Editor', valueConvert: parseInt, type: 'fontSize' })
     fontSize = 14;
 
-    @meta({name: 'Font color', group: 'Editor', type: 'color'})
+    @meta({ name: 'Font color', group: 'Editor', type: 'color' })
     fontColor = '#51f41c';
 
-    @meta({name: 'jQuery', group: 'Plugins', type: 'checkbox'})
-    jQuery = true;
+    @meta({ name: 'jQuery', group: 'Plugins', type: 'checkbox' })
+    public jQuery: boolean = true;
 
-    @meta({name: 'Card Style', group: 'Style', type: MatCheckbox})
+    @meta({ name: 'Card Style', group: 'Style', type: MatCheckbox })
     cardStyle = true;
 
     @meta({
@@ -62,32 +94,68 @@ export class ExampleEditorOptions {
         name: 'Framework',
         description: 'Whether to include any additional framework',
         type: 'options',
-        options: ['None', {text: 'AngularJS', value: 'angular'}, {text: 'Backbone.js', value: 'backbone'}]
+        options: ['None', { text: 'AngularJS', value: 'angular' }, { text: 'Backbone.js', value: 'backbone' }]
     })
     framework = 'None';
-
 }
 
-export class ExampleStudentOptions {
+export interface IExampleStudentOptions {
+    birth: string;
+    name: string;
+    description: string;
+    age: number;
+    telephone: string;
+    gender: string;
+    editor: ExampleEditorOptions;
+}
 
-    @meta({name: 'Birth', group: 'Basic Information', type: 'date', order: 4})
+
+export class ExampleStudentOptions implements IExampleStudentOptions{
+
+    @meta({ name: 'Birth', group: 'Basic Information', type: 'date', order: 4 })
     birth = '2018-05-08';
 
-    @meta({name: 'Name', group: 'Basic Information', type: 'text', order: 1, link: 'http://www.baidu.com'})
+    @meta({ name: 'Name', group: 'Basic Information', type: 'text', order: 1, link: 'http://www.baidu.com' })
     name = 'Lily';
 
-    @meta({name: 'Description', group: 'Basic Information', type: 'text', readonly:true, order: 1, link: 'http://www.baidu.com'})
+    @meta({ name: 'Description', group: 'Basic Information', type: 'text', readonly: true, order: 1, link: 'http://www.baidu.com' })
     description = 'A readonly string';
 
-    @meta({name: 'Age', group: 'Basic Information1', valueConvert: parseInt, type: 'text', order: 2})
+    @meta({ name: 'Age', group: 'Basic Information1', valueConvert: parseInt, type: 'text', order: 2 })
     age = 19;
 
-    @meta({name: 'Telephone', type: 'telephone', group: 'Basic Information1', hidden: true})
+    @meta({ name: 'Telephone', type: 'telephone', group: 'Basic Information1', hidden: true })
     telephone;
 
-    @meta({name: 'Gender', group: 'Basic Information', type: 'sex', order: 3})
+    @meta({ name: 'Gender', group: 'Basic Information', type: 'sex', order: 3 })
     gender = 'male';
 
-    @meta({name: 'Editor Preference', type: 'subItems', initState: 'visible'})
+    @meta({ name: 'Editor Preference', type: 'subItems', initState: 'visible' })
     editor: ExampleEditorOptions = new ExampleEditorOptions();
+}
+
+
+export class DynamicExampleStudentOptions implements IExampleStudentOptions, IPropertyGridMetaDataProvider {
+
+    birth = '2018-05-08';
+    name = 'Lily';
+    description = 'A readonly string';
+    age = 19;
+    telephone;
+    gender = 'male';
+    editor: ExampleEditorOptions = new ExampleEditorOptions();
+
+    public providePropertyGridMetaData(): PropertyItemMeta[] {
+        let properties: PropertyItemMeta[] = [];
+        properties.push({ key: 'birth', name: 'Birth', group: 'Basic Information', type: 'date', order: 4 });
+        properties.push({ key: 'name', name: 'Name', group: 'Basic Information', type: 'text', order: 1, link: 'http://www.baidu.com' });
+        properties.push({ key: 'description', name: 'Description', group: 'Basic Information', type: 'text', readonly: true, order: 1, link: 'http://www.baidu.com' });
+        if (this.gender == 'male') {
+            properties.push({ key: 'age', name: 'Age', group: 'Basic Information1', valueConvert: parseInt, type: 'text', order: 2 });
+            properties.push({ key: 'telephone', name: 'Telephone', type: 'telephone', group: 'Basic Information1', hidden: true });
+            properties.push({ key: 'editor', name: 'Editor Preference', type: 'subItems', initState: 'visible' });
+        }
+        properties.push({ key: 'gender', name: 'Gender', group: 'Basic Information', type: 'sex', order: 3 });
+        return properties;
+    }
 }

--- a/src/app/showcase/app.component.ts
+++ b/src/app/showcase/app.component.ts
@@ -22,11 +22,13 @@ export class AppComponent {
 
 @Component({
     selector: 'app-text-editor',
-    template: `<input type="text" [value]="value" (change)="valueChange.emit($event.target.value)"/>`
+    template: `<input type="text" [value]="value" [disabled]="disabled" (change)="valueChange.emit($event.target.value)" />`
 })
 export class SimpleTextEditorComponent implements IDynamicComponent<string> {
     value: string;
     valueChange: EventEmitter<string> = new EventEmitter<string>();
+    disabled: boolean;
+    disabledChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 }
 
 export class ExampleEditorOptions {
@@ -42,7 +44,7 @@ export class ExampleEditorOptions {
     @meta({name: 'Font color', group: 'Editor', type: 'color'})
     fontColor = '#51f41c';
 
-    @meta({name: 'jQuery', group: 'Plugins', type: MatCheckbox})
+    @meta({name: 'jQuery', group: 'Plugins', type: 'checkbox'})
     jQuery = true;
 
     @meta({name: 'Card Style', group: 'Style', type: MatCheckbox})
@@ -73,6 +75,9 @@ export class ExampleStudentOptions {
 
     @meta({name: 'Name', group: 'Basic Information', type: 'text', order: 1, link: 'http://www.baidu.com'})
     name = 'Lily';
+
+    @meta({name: 'Description', group: 'Basic Information', type: 'text', readonly:true, order: 1, link: 'http://www.baidu.com'})
+    description = 'A readonly string';
 
     @meta({name: 'Age', group: 'Basic Information1', valueConvert: parseInt, type: 'text', order: 2})
     age = 19;

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Allows a property to be displayed using the default editor but appear readonly.
Adds the 'disabled' attribute to the input element.
It also adds the 'property-grid-readonly' style (which just a placeholder) to the containing 'tr' element, allowing customizable styling options.