### PR TITLE
feat: added additional meta data

### DIFF
--- a/projects/ngx-property-grid/src/lib/property-item-meta.ts
+++ b/projects/ngx-property-grid/src/lib/property-item-meta.ts
@@ -20,6 +20,7 @@ export interface PropertyItemMeta {
   valueChanged?: (newValue: any, oldValue: any) => void;
   showHelp?: boolean; // default True.
   link?: string; // help link
+  additional?: any; // additional data you can pass to the property
 }
 
 

--- a/src/app/showcase/app.component.html
+++ b/src/app/showcase/app.component.html
@@ -4,7 +4,7 @@
 
         <ngx-property-grid [width]="'400px'" [options]="student" [showHelp]="true" [groupCollapse]="true" [cardStyle]="student.editor.cardStyle">
             <ng-template ngxTemplate="text" let-p>
-                <input type="text" [value]="p.value" (change)="p.value = $event.target.value">
+                <input type="text" [value]="p.value" (change)="p.value = $event.target.value" [disabled]="p.meta?.additional?.disabled">
             </ng-template>
             <ng-template ngxTemplate="fontSize" let-pp>
                 <input matInput type="number" placeholder="Value" [(ngModel)]="pp.value">

--- a/src/app/showcase/app.component.ts
+++ b/src/app/showcase/app.component.ts
@@ -77,6 +77,9 @@ export class ExampleStudentOptions {
     @meta({name: 'Age', group: 'Basic Information1', valueConvert: parseInt, type: 'text', order: 2})
     age = 19;
 
+    @meta({name: 'Id', group: 'Basic Information1', type: 'text', order: 3, additional: { disabled: true }})
+    id = '123456789';
+
     @meta({name: 'Telephone', type: 'telephone', group: 'Basic Information1', hidden: true})
     telephone;
 


### PR DESCRIPTION
Adds an additional property to the metadata, which you can reference in the template via `p.meta.additional.myProperty`

![image](https://user-images.githubusercontent.com/5423967/198328563-6aa0488e-91a4-45b9-8257-6142692ab470.png)

resolve #63 
